### PR TITLE
Update GitHub Actions for keyless auth GAR push

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Set Tag and SHA
         run: |
-          CLEAN_TAG=$(echo "${{ github.event.pull_request.head.ref  }}"  | tr / -)
+          CLEAN_TAG=$(echo "${{ github.event.pull_request.head.ref }}" | tr / -)
           echo "TAG=$CLEAN_TAG" >> $GITHUB_ENV
           echo "SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,6 +20,7 @@ jobs:
         name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
+          token_format: 'access_token'
           workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.SERVICE_ACCOUNT }}
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,22 +8,33 @@ on:
 jobs:
 
   docker-push:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     runs-on: ubuntu-22.04
+
     steps:
       - uses: actions/checkout@v4
+
+      - id: auth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.SERVICE_ACCOUNT }}
+
       - name: Set Tag and SHA
         run: |
           CLEAN_TAG=$(echo "${{ github.event.pull_request.head.ref  }}"  | tr / -)
           echo "TAG=$CLEAN_TAG" >> $GITHUB_ENV
           echo "SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+
       - name: Build
         run: >
           docker build -t ${{ secrets.GAR_LOCATION }}/${{ secrets.GAR_PROJECT_ID }}/docker-images/eq-runner-maintenance-page:$TAG .
+
       - name: Push to GAR
-        env:
-          GAR_SERVICE_KEY: ${{ secrets.GAR_SERVICE_KEY }}
         run: |
-          echo $GAR_SERVICE_KEY | docker login -u _json_key --password-stdin https://${{ secrets.GAR_LOCATION }}
           gcloud auth configure-docker ${{ secrets.GAR_LOCATION }}
           echo "Pushing to GAR with tag $TAG"
           docker push ${{ secrets.GAR_LOCATION }}/${{ secrets.GAR_PROJECT_ID }}/docker-images/eq-runner-maintenance-page:$TAG


### PR DESCRIPTION
### What is the context of this PR?
We need to move to keyless authentication to allow pushing of our Docker images from our PR branches.

### How to review
Ensure that the GitHub action passes for this PR and the image is pushed successfully. **NOTE -** This PR build will fail until the keyless auth config is in place.

Note: For some reason, we were getting errors in our GHA after repeatedly trying to rerun, saying `Error: google-github-actions/auth failed with: the GitHub Action workflow must specify exactly one of "workload_identity_provider" or "credentials_json"!`. However, the env vars mentioned were already set so we're not sure what might have caused this. If it happens again, try pushing up an empty commit to see if the GHA correctly builds again.

